### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "urls": [
+    ["eiscp/__init__.py", "github:cbrand/eiscp-micropython/src/eiscp/__init__.py"],
+    ["eiscp/core.py", "github:cbrand/eiscp-micropython/src/eiscp/core.py"],
+    ["eiscp/discovery.py", "github:cbrand/eiscp-micropython/src/eiscp/discovery.py"],
+    ["eiscp/eiscp.py", "github:cbrand/eiscp-micropython/src/eiscp/eiscp.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the library compatible with the MicroPython Package Manager (MIP).

With this change, users can install the library using:
\\\

This will install the eISCP (Integra Serial Control Protocol) modules for controlling Onkyo/Integra devices.